### PR TITLE
Serverclass support

### DIFF
--- a/actian_jdbc/connection-dialog.tcd
+++ b/actian_jdbc/connection-dialog.tcd
@@ -2,6 +2,7 @@
   <connection-config>
     <authentication-mode value='Basic' />
     <authentication-options>
+      <option name="None" default="false" value="auth-none" />
       <option name="UsernameAndPassword" default="true" />
     </authentication-options>
     <db-name-prompt value="Database: " />

--- a/actian_odbc/connection-dialog.tcd
+++ b/actian_odbc/connection-dialog.tcd
@@ -2,6 +2,7 @@
   <connection-config>
     <authentication-mode value='Basic' />
     <authentication-options>
+      <option name="None" default="false" value="auth-none" />
       <option name="UsernameAndPassword" default="true" />
     </authentication-options>
     <db-name-prompt value="Database: " />

--- a/actian_odbc/connectionBuilder.js
+++ b/actian_odbc/connectionBuilder.js
@@ -15,6 +15,12 @@
         params["PWD"] = attr["password"];
     }
     params["DATABASE"] = attr["dbname"];
+    var slash_index = params["DATABASE"].search('/');
+    if (slash_index >= 0)
+    {
+        params["ServerType"] = params["DATABASE"].slice(slash_index + 1);  // determine server class (skip slash)
+        params["DATABASE"] = params["DATABASE"].slice(0, slash_index);  // strip class, leaving only database name
+    }
 
     var formattedParams = [];
 


### PR DESCRIPTION
Also includes login details to be omitted and DBMS makes use of local OS Auth.

Serverclass can be specified in dbname just like command line tools. For example,

    mydbname/myclass