### PR TITLE
Hab6 rework

### DIFF
--- a/actian_jdbc/connectionBuilder.js
+++ b/actian_jdbc/connectionBuilder.js
@@ -1,29 +1,15 @@
 (function dsbuilder(attr)
 {
-    var params = [];
+    var urlBuilder = null;
 
     if (attr["server"].toLowerCase() == "(local)")  // match ODBC implementation, even though JDBC driver does not understand (local)
     {
-        attr["server"] = "localhost";
-        // local connection, no auth specified
-        // port is required
+        urlBuilder = "jdbc:ingres://" + "localhost:" + attr[connectionHelper.attributePort] + "/" + attr[connectionHelper.attributeDatabase] + ";";
     }
     else
     {
-        params["UID"] = attr["username"];
-        params["PWD"] = attr["password"];
+        urlBuilder = "jdbc:ingres://" + attr[connectionHelper.attributeServer] + ":" + attr[connectionHelper.attributePort] + "/" + attr[connectionHelper.attributeDatabase] + ";";
     }
-
-    var urlBuilder = "jdbc:ingres://" + attr["server"] + ":" + attr["port"] + "/" + attr["dbname"] + ";";
-
-    var formattedParams = [];
-
-    for (var key in params) {
-        formattedParams.push(connectionHelper.formatKeyValuePair(key, params[key]));
-    }
-
-    urlBuilder += formattedParams.join(";")
 
     return [urlBuilder];
-}) 
- 
+})

--- a/actian_jdbc/connectionFields.xml
+++ b/actian_jdbc/connectionFields.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<connection-fields>
+  <field name="server" label="Server" value-type="string" category="endpoint" >
+	  <!-- The regex for the Server entry field allows normal/expected forms of host names
+	       plus case-insensitive forms of the word "local" contained within parenthesis.
+	       This value of "(local)" is converted to "localhost" in connectionBuilder.js
+	       for use in the JDBC connection string. -->
+    <validation-rule reg-exp="^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$|(^\([lL][oO][cC][aA][lL]\)$)"/>
+  </field>
+  <field name="port" label="Port" value-type="string" category="endpoint" default-value="27839" />
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+  <field name="username" label="Username" value-type="string" category="authentication" />
+  <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
+  <field name="sslmode" label="Require SSL" value-type="boolean" category="general" default-value="" >
+    <boolean-options>
+      <false-value value="" />
+      <true-value value="require" />
+    </boolean-options>
+  </field>
+</connection-fields>

--- a/actian_jdbc/connectionFields.xml
+++ b/actian_jdbc/connectionFields.xml
@@ -2,9 +2,9 @@
 <connection-fields>
   <field name="server" label="Server" value-type="string" category="endpoint" >
 	  <!-- The regex for the Server entry field allows normal/expected forms of host names
-	       plus case-insensitive forms of the word "local" contained within parenthesis.
-	       This value of "(local)" is converted to "localhost" in connectionBuilder.js
-	       for use in the JDBC connection string. -->
+	       and also case-insensitive forms of the word "local" contained within parenthesis.
+	       This Server value of "(local)" is converted to "localhost" in connectionBuilder.js
+	       for use in the JDBC connection string to connect to the local instance. -->
     <validation-rule reg-exp="^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$|(^\([lL][oO][cC][aA][lL]\)$)"/>
   </field>
   <field name="port" label="Port" value-type="string" category="endpoint" default-value="27839" />

--- a/actian_jdbc/connectionMetadata.xml
+++ b/actian_jdbc/connectionMetadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<connection-metadata>
+  <database enabled='true'>
+    <field />
+  </database>
+  <schema enabled='false' />
+</connection-metadata>

--- a/actian_jdbc/connectionProperties.js
+++ b/actian_jdbc/connectionProperties.js
@@ -1,0 +1,14 @@
+(function propertiesbuilder(attr) {
+
+    var props = {};
+
+    props["user"] = attr[connectionHelper.attributeUsername];
+    props["password"] = attr[connectionHelper.attributePassword];
+
+    if (attr[connectionHelper.attributeSSLMode] == "require") {
+        props["ssl"] = "true";
+        props["sslmode"] = "require";
+    }
+
+    return props;
+})

--- a/actian_jdbc/connectionResolver.tdr
+++ b/actian_jdbc/connectionResolver.tdr
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 <tdr class='actian_jdbc'>
-	<connection-resolver>
+  <connection-resolver>
     <connection-builder>
       <script file='connectionBuilder.js'/>
     </connection-builder>
@@ -13,8 +13,13 @@
           <attr>dbname</attr>
           <attr>username</attr>
           <attr>password</attr>
+          <attr>authentication</attr>
+          <attr>sslmode</attr>
         </attribute-list>
       </required-attributes>
     </connection-normalizer>
-	</connection-resolver>
+    <connection-properties>
+      <script file="connectionProperties.js"/>
+    </connection-properties>
+  </connection-resolver>
 </tdr>

--- a/actian_jdbc/manifest.xml
+++ b/actian_jdbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='actian_jdbc' superclass='jdbc' plugin-version='0.0.0' name='Actian Avalanche JDBC' version='18.1'>
+<connector-plugin class='actian_jdbc' superclass='jdbc' plugin-version='1.0.2' name='Actian Avalanche JDBC' version='18.1'>
   <!--
       Including company_name results in "By Actian" being added to the end of the connector name.
       Not including company_name but including <vendor-information> with url,
@@ -26,16 +26,16 @@
       <customization name="CAP_SELECT_INTO" value="yes"/>
       <customization name="CAP_SELECT_TOP_INTO" value="yes"/>
       <customization name="CAP_CREATE_TEMP_TABLES" value="yes"/>
-      <customization name="CAP_INDEX_TEMP_TABLES" value="yes"/>  
+      <customization name="CAP_INDEX_TEMP_TABLES" value="yes"/>
       <customization name="CAP_QUERY_BOOLEXPR_TO_INTEXPR" value="yes"/>
-      <customization name="CAP_QUERY_GROUP_BY_BOOL" value="yes"/> 
-      <customization name="CAP_QUERY_GROUP_BY_DEGREE" value="yes"/>  
-      <customization name="CAP_QUERY_GROUP_BY_ALIAS" value="yes"/> 
-      <customization name="CAP_QUERY_INCLUDE_GROUP_BY_COLUMNS_IN_SELECT" value="no"/> 
+      <customization name="CAP_QUERY_GROUP_BY_BOOL" value="yes"/>
+      <customization name="CAP_QUERY_GROUP_BY_DEGREE" value="yes"/>
+      <customization name="CAP_QUERY_GROUP_BY_ALIAS" value="yes"/>
+      <customization name="CAP_QUERY_INCLUDE_GROUP_BY_COLUMNS_IN_SELECT" value="no"/>
       <customization name="CAP_QUERY_HAVING_REQUIRES_GROUP_BY" value="no"/>
-      <customization name="CAP_QUERY_SORT_BY" value="yes"/> 
+      <customization name="CAP_QUERY_SORT_BY" value="yes"/>
       <customization name="CAP_QUERY_SUBQUERIES" value="yes"/>
-      <customization name="CAP_QUERY_TOP_N" value="yes"/> 
+      <customization name="CAP_QUERY_TOP_N" value="yes"/>
       <customization name="CAP_QUERY_TOP_SAMPLE" value="no"/>
       <customization name="CAP_QUERY_TOP_SAMPLE_PERCENT" value="no"/>
       <customization name='CAP_QUERY_TOPSTYLE_LIMIT' value='no' />
@@ -43,19 +43,20 @@
       <customization name='CAP_QUERY_TOPSTYLE_TOP' value='yes' />
       <customization name='CAP_QUERY_TOP_0_METADATA' value='no' />
       <customization name="CAP_QUERY_WHERE_FALSE_METADATA" value="yes"/>
-      <customization name="CAP_QUERY_SUBQUERIES_WITH_TOP" value="no"/> 
-      <customization name="CAP_SUPPORTS_SPLIT_FROM_LEFT" value="no"/> 
-      <customization name="CAP_SUPPORTS_SPLIT_FROM_RIGHT" value="no"/> 
+      <customization name="CAP_QUERY_SUBQUERIES_WITH_TOP" value="no"/>
+      <customization name="CAP_SUPPORTS_SPLIT_FROM_LEFT" value="no"/>
+      <customization name="CAP_SUPPORTS_SPLIT_FROM_RIGHT" value="no"/>
       <customization name="CAP_SUPPORTS_UNION" value="yes"/>
       <customization name="CAP_QUERY_SUBQUERY_QUERY_CONTEXT" value="yes"/>
-      <customization name="CAP_QUERY_ALLOW_PARTIAL_AGGREGATION" value="yes"/> 
+      <customization name="CAP_QUERY_ALLOW_PARTIAL_AGGREGATION" value="yes"/>
       <customization name="CAP_QUERY_TIME_REQUIRES_CAST" value="yes"/>
       <customization name='CAP_QUERY_SELECT_ALIASES_SORTED' value='yes' />
       <customization name='CAP_QUERY_SORT_BY_DEGREE' value='yes' />
 
     </customizations>
   </connection-customization>
-  <connection-dialog file='connection-dialog.tcd'/>
+  <connection-fields file='connectionFields.xml'/>
+  <connection-metadata file='connectionMetadata.xml'/>
   <connection-resolver file="connectionResolver.tdr"/>
   <dialect file='dialect.tdd'/>
 </connector-plugin>


### PR DESCRIPTION
### Notable Changes to Connector Source Code for this PR

1. Reworked the JDBC connection dialog code in accordance with guidelines for Connection Dialog [v2](https://tableau.github.io/connector-plugin-sdk/docs/mcd) (versus older [v1](https://tableau.github.io/connector-plugin-sdk/docs/ui.html) guidelines).
2. Enabled use of case-insensitive **Server** value "(local)" that is auto-converted to "localhost" for the JDBC connection string.
     a. Server values tested successfully:  `(local)`, `(LOCAL)`, `(Local)`, `(LoCal)`, `localhost`
3. Set plugin-version to `1.0.2` in manifest.xml for both the JDBC and ODBC connectors.

### Verification of Taco Code
The code for both the JDBC and ODBC connectors has been:
- Packaged
- Signed
- Tested as tacos to log into Tableau Desktop
- Used to test the TDVT suite

#### Jarsigner verification output (same for both the JDBC and ODBC taco)  
     jar verified.
     The signer certificate will expire on 2023-10-08.
     The timestamp will expire on 2031-11-09.

### Tableau TDVT Test Suite Results

Connector | Passed | Failed | Total Tests | Total Time
--|--|--|--|--
JDBC | 819 | 46 | 865 | 50.13s
ODBC | 823 | 42 | 865 | 25.78s

TDVT differences will be investigated via #25