### PR TITLE
Fix CHAR padding mismatch in TDVT runs

### DIFF
--- a/actian_jdbc/dialect.tdd
+++ b/actian_jdbc/dialect.tdd
@@ -626,7 +626,7 @@
 		<formula part='dayofyear'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDDD&apos;)</formula>
 		<formula part='day'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDD&apos;)</formula>
 		<formula part='weekday'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDay&apos;)</formula>
-		<formula part='week'> CAST(CAST(WEEK(%2,0) AS INTEGER) AS CHAR(3)) </formula>
+		<formula part='week'> CAST(CAST(WEEK(%2,0) AS INTEGER) AS VARCHAR(3)) </formula>
 		<formula part='hour'>TO_CHAR(CAST(%2 AS TIMESTAMP(7)), &apos;FMHH24&apos;)</formula>
 		<formula part='minute'>TO_CHAR(CAST(%2 AS TIMESTAMP(7)), &apos;FMMI&apos;)</formula>
 		<formula part='second'>TO_CHAR(CAST(%2 AS TIMESTAMP(7)), &apos;FMSS&apos;)</formula>
@@ -641,7 +641,7 @@
 		<formula part='dayofyear'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMDDD&apos;)</formula>
 		<formula part='day'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMDD&apos;)</formula>
 		<formula part='weekday'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMDay&apos;)</formula>
-		<formula part='week'>CAST(CAST(WEEK(%2,0) +1 AS INTEGER) AS CHAR(6))</formula>
+		<formula part='week'>CAST(CAST(WEEK(%2,0) +1 AS INTEGER) AS VARCHAR(6))</formula>
 		<formula part='hour'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMHH24&apos;)</formula>
 		<formula part='minute'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMMI&apos;)</formula>
 		<formula part='second'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMSS&apos;)</formula>
@@ -656,7 +656,7 @@
 		<formula part='dayofyear'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMDDD&apos;)</formula>
 		<formula part='day'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMDD&apos;)</formula>
 		<formula part='weekday'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMDay&apos;)</formula>
-		<formula part='week'>CAST(CAST(WEEK(%2,0) AS INTEGER) AS CHAR(4))</formula>
+		<formula part='week'>CAST(CAST(WEEK(%2,0) AS INTEGER) AS VARCHAR(4))</formula>
 		<formula part='hour'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMHH24&apos;)</formula>
 		<formula part='minute'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMMI&apos;)</formula>
 		<formula part='second'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMSS&apos;)</formula>
@@ -671,7 +671,7 @@
 		<formula part='dayofyear'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMDDD&apos;)</formula>
 		<formula part='day'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMDD&apos;)</formula>
 		<formula part='weekday'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMDay&apos;)</formula>
-		<formula part='week'> CAST(CAST(WEEK(%2,0) AS INTEGER) AS CHAR(5))</formula>
+		<formula part='week'> CAST(CAST(WEEK(%2,0) AS INTEGER) AS VARCHAR(5))</formula>
 		<formula part='hour'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMHH24&apos;)</formula>
 		<formula part='minute'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMMI&apos;)</formula>
 		<formula part='second'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMSS&apos;)</formula>
@@ -687,7 +687,7 @@
 		<formula part='dayofyear'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDDD&apos;)</formula>
 		<formula part='day'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDD&apos;)</formula>
 		<formula part='weekday'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDay&apos;)</formula>
-		<formula part='week'> CAST(Cast(WEEK(%2,0) AS INTEGER) AS CHAR(3)) </formula>
+		<formula part='week'> CAST(Cast(WEEK(%2,0) AS INTEGER) AS VARCHAR(3)) </formula>
 		<formula part='hour'>TO_CHAR(CAST(%2 AS TIMESTAMP(2)), &apos;FMHH24&apos;)</formula>
 		<formula part='minute'>TO_CHAR(CAST(%2 AS TIMESTAMP(2)), &apos;FMMI&apos;)</formula>
 		<formula part='second'>TO_CHAR(CAST(%2 AS TIMESTAMP(2)), &apos;FMSS&apos;)</formula>

--- a/actian_odbc/dialect.tdd
+++ b/actian_odbc/dialect.tdd
@@ -626,7 +626,7 @@
 		<formula part='dayofyear'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDDD&apos;)</formula>
 		<formula part='day'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDD&apos;)</formula>
 		<formula part='weekday'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDay&apos;)</formula>
-		<formula part='week'> CAST(CAST(WEEK(%2,0) AS INTEGER) AS CHAR(3)) </formula>
+		<formula part='week'> CAST(CAST(WEEK(%2,0) AS INTEGER) AS VARCHAR(3)) </formula>
 		<formula part='hour'>TO_CHAR(CAST(%2 AS TIMESTAMP(7)), &apos;FMHH24&apos;)</formula>
 		<formula part='minute'>TO_CHAR(CAST(%2 AS TIMESTAMP(7)), &apos;FMMI&apos;)</formula>
 		<formula part='second'>TO_CHAR(CAST(%2 AS TIMESTAMP(7)), &apos;FMSS&apos;)</formula>
@@ -641,7 +641,7 @@
 		<formula part='dayofyear'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMDDD&apos;)</formula>
 		<formula part='day'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMDD&apos;)</formula>
 		<formula part='weekday'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMDay&apos;)</formula>
-		<formula part='week'>CAST(CAST(WEEK(%2,0) +1 AS INTEGER) AS CHAR(6))</formula>
+		<formula part='week'>CAST(CAST(WEEK(%2,0) +1 AS INTEGER) AS VARCHAR(6))</formula>
 		<formula part='hour'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMHH24&apos;)</formula>
 		<formula part='minute'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMMI&apos;)</formula>
 		<formula part='second'>TO_CHAR(CAST(%2 AS TIMESTAMP(5)), &apos;FMSS&apos;)</formula>
@@ -656,7 +656,7 @@
 		<formula part='dayofyear'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMDDD&apos;)</formula>
 		<formula part='day'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMDD&apos;)</formula>
 		<formula part='weekday'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMDay&apos;)</formula>
-		<formula part='week'>CAST(CAST(WEEK(%2,0) AS INTEGER) AS CHAR(4))</formula>
+		<formula part='week'>CAST(CAST(WEEK(%2,0) AS INTEGER) AS VARCHAR(4))</formula>
 		<formula part='hour'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMHH24&apos;)</formula>
 		<formula part='minute'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMMI&apos;)</formula>
 		<formula part='second'>TO_CHAR(CAST(%2 AS TIMESTAMP(3)), &apos;FMSS&apos;)</formula>
@@ -671,7 +671,7 @@
 		<formula part='dayofyear'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMDDD&apos;)</formula>
 		<formula part='day'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMDD&apos;)</formula>
 		<formula part='weekday'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMDay&apos;)</formula>
-		<formula part='week'> CAST(CAST(WEEK(%2,0) AS INTEGER) AS CHAR(5))</formula>
+		<formula part='week'> CAST(CAST(WEEK(%2,0) AS INTEGER) AS VARCHAR(5))</formula>
 		<formula part='hour'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMHH24&apos;)</formula>
 		<formula part='minute'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMMI&apos;)</formula>
 		<formula part='second'>TO_CHAR(CAST(%2 AS TIMESTAMP(1)), &apos;FMSS&apos;)</formula>
@@ -687,7 +687,7 @@
 		<formula part='dayofyear'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDDD&apos;)</formula>
 		<formula part='day'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDD&apos;)</formula>
 		<formula part='weekday'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDay&apos;)</formula>
-		<formula part='week'> CAST(Cast(WEEK(%2,0) AS INTEGER) AS CHAR(3)) </formula>
+		<formula part='week'> CAST(Cast(WEEK(%2,0) AS INTEGER) AS VARCHAR(3)) </formula>
 		<formula part='hour'>TO_CHAR(CAST(%2 AS TIMESTAMP(2)), &apos;FMHH24&apos;)</formula>
 		<formula part='minute'>TO_CHAR(CAST(%2 AS TIMESTAMP(2)), &apos;FMMI&apos;)</formula>
 		<formula part='second'>TO_CHAR(CAST(%2 AS TIMESTAMP(2)), &apos;FMSS&apos;)</formula>


### PR DESCRIPTION
### Summary of problem

TDVT test cases are failing when using the Actian **JDBC** connector due to mismatching **actual** versus **expected** results caused by result values being padded with trailing spaces. 

The failing tests:  

    DATENAME('week', [date2], 'sunday')
    DATENAME('week', [datetime0], 'sunday')
    DATENAME('week', [date2])
    DATENAME('week', [datetime0])

_Note: This problem seems to only affect the Actian **JDBC** connector. The **ODBC** connector is unaffected since the results when using the ODBC connector returned are not padded even though the dialect translation is the same._

### Example results excerpt showing differences before and after fix
| Without Fix | With Fix |
|--|--|
| <pre><code>""12    ""</code><br><code>""17    ""</code><br><code>""18    ""</code><br><code>""2     ""</code></pre> | <pre><code>""12""</code><br><code>""17""</code><br><code>""18""</code><br><code>""2"" |

### Solution
The fix changes the dialect translation for these particular tests cases from using `CAST ... CHAR` to `CAST ... VARCHAR` for the JDBC connector. The ODBC connector dialect is also updated to match the JDBC connector although the change has no impact on the ODBC connector.

### TDVT test results

Connector | Passed | Failed | Total
--|--|--|--
JDBC without fix | 819 | 49 | 868
JDBC with fix | 823 | 45 | 868
ODBC (with/without fix) | 823 | 45 | 868