### PR TITLE
Override function TIME1899

### DIFF
--- a/actian_jdbc/dialect.tdd
+++ b/actian_jdbc/dialect.tdd
@@ -455,6 +455,10 @@
 		<argument type='str' />
 		<argument type='str' />
     </function>
+    <function group='system' name='TIME1899' return-type='datetime'>
+		<formula>TIME(CHAR(DATEPART('hour',%1)) + ':' + CHAR(DATEPART('minute',%1)) + ':' + CHAR(DATEPART('second',%1)))</formula>
+		<argument type='datetime' />
+    </function>
     <function group='date' name='YEAR' return-type='int'>
 		<formula>YEAR(%1)</formula>
 		<argument type='datetime' />

--- a/actian_odbc/dialect.tdd
+++ b/actian_odbc/dialect.tdd
@@ -455,6 +455,10 @@
 		<argument type='str' />
 		<argument type='str' />
     </function>
+    <function group='system' name='TIME1899' return-type='datetime'>
+		<formula>TIME(CHAR(DATEPART('hour',%1)) + ':' + CHAR(DATEPART('minute',%1)) + ':' + CHAR(DATEPART('second',%1)))</formula>
+		<argument type='datetime' />
+    </function>
     <function group='date' name='YEAR' return-type='int'>
 		<formula>YEAR(%1)</formula>
 		<argument type='datetime' />


### PR DESCRIPTION
### Symptom
The TDVT test case **calcs_data.time/time1** fails to match expected results as documented in Jira ticket [II-12232](https://actian.atlassian.net/browse/II-12232). A similar failure (with same root cause) occurs when performing an **Extract Data** operation as required by Tableau [Manual QA Tests](https://tableau.github.io/connector-plugin-sdk/docs/manual-test).

### Cause
The [DDL of the Calcs table](https://github.com/tableau/connector-plugin-sdk/blob/master/tests/datasets/TestV1/DDL/Calcs.sql) in the Tableau TDVT dataset defines the **time1** column as type `TIME` and yet Tableau itself does not have a `TIME` data type (references [A](https://community.tableau.com/s/question/0D54T00000F352FSAR/time-in-float-format-999999-tableau-reading-incorrectly), [B](https://community.tableau.com/s/question/0D54T00000C6iuMSAR/time-field-showing-odd-date), [C](https://community.tableau.com/s/question/0D54T00000C6oA1SAJ/time-format-turns-into-a-dated-format-with-12301899), [D](https://kb.tableau.com/articles/howto/isolate-time-from-date-and-time-field?_ga=2.144732914.737639449.1693429107-86128355.1689967215&_gl=1*ezk8no*_ga*ODYxMjgzNTUuMTY4OTk2NzIxNQ..*_ga_8YLN0SNXVS*MTY5MzYwMzQ3OC4zNS4xLjE2OTM2MDM1MTkuMC4wLjA.)), thus workarounds are required to extract and/or display only the time portion of DATETIME/TIMESTAMP data in Tableau.

### Tableau Built-in Function
The Tableau Connector SDK sample dialect **SQLDialect** contains a function called [TIME1899](https://github.com/tableau/connector-plugin-sdk/blob/4cbc26c6c358224774cb8e5371f6b5292dbe531c/samples/components/dialects/SQLDialect.tdd#L51C38-L51C38) that overrides a Tableau _**built-in**_ function of the same name, which translates time values so that they contain a pre-pended date of `1899-12-30`. In other words, the purpose of the **TIME1899** function is to translate data source TIME data into DATETIME data that Tableau can handle which later can be dealt with in Tableau for extracting parts of the datetime value as needed.

### Proposed Solution
Override the built-in **TIME1899** function so that "time" data returned by the JDBC and ODBC drivers is preserved by the Actian connector(s). The Tableau built-in **TIME1899** function still fixes up the "time" data (somewhere before the data is shown in Tableau Desktop) with the fixed date of `1899-12-30`, but the dialect fix allows TDVT and manual QA tests to succeed.

### Test Results
The proposed solution works both with the TDVT suite and the "Extract Data" operation of the [Manual QA tests](https://tableau.github.io/connector-plugin-sdk/docs/manual-test).  The fix allows the TDVT test **calcs_data.time/time1** to succeed in matching expected results and no adverse affects are seen with any other TDVT test cases.