### PR TITLE
TDVT DATENAME and DATEPART fixes with SOW = monday for II-12238 and II-12239

### DIFF
--- a/actian_jdbc/dialect.tdd
+++ b/actian_jdbc/dialect.tdd
@@ -534,7 +534,7 @@
 		<formula part='dayofyear'>TIMESTAMPDIFF(DAY,CAST(%2 AS TIMESTAMP(2)), CAST(%3 AS ANSIDATE))</formula>
         <formula part='day'>TIMESTAMPDIFF(DAY,CAST(%2 AS ANSIDATE), CAST(%3 AS ANSIDATE))</formula>
 		<formula part='weekday'>TIMESTAMPDIFF(DAY,CAST(%2 AS ANSIDATE), CAST(%3 AS ANSIDATE))</formula>
-		<formula  part='week'>CAST(ROUND(TIMESTAMPDIFF(DAY,CAST(%2 AS ANSIDATE), CAST(%3 AS ANSIdATE))/7.0,0) AS INTEGER)</formula>
+		<formula  part='week'>CAST(ROUND(TIMESTAMPDIFF(DAY,CAST(%2 AS ANSIDATE), CAST(%3 AS ANSIDATE))/7.0,0) AS INTEGER)</formula>
         <formula part='hour'>TIMESTAMPDIFF(HOUR,CAST(%2 AS TIMESTAMP), CAST(%3 AS TIMESTAMP))</formula>
 		<formula part='minute'>TIMESTAMPDIFF(MINUTE,CAST(%2 AS TIMESTAMP), CAST(%3 AS TIMESTAMP))</formula>
 		<formula part='second'>TIMESTAMPDIFF(SECOND,CAST(%2 AS TIMESTAMP), CAST(%3 AS TIMESTAMP))</formula>
@@ -691,7 +691,9 @@
 		<formula part='dayofyear'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDDD&apos;)</formula>
 		<formula part='day'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDD&apos;)</formula>
 		<formula part='weekday'>TO_CHAR(CAST(%2 AS ANSIDATE), &apos;FMDay&apos;)</formula>
-		<formula part='week'> CAST(Cast(WEEK(%2,0) AS INTEGER) AS VARCHAR(3)) </formula>
+		<!-- The conditional check %3=1 in the next formula part checks if the test case 3rd parameter is 'monday' ('sunday'=0, 'monday'=1)-->
+		<!-- Possible TODO: Handle other DOW values for the 3rd parameter (e.g. 'wednesday', 'thursday', etc.)-->
+		<formula part='week'>IF(%3=1, CAST(CAST(WEEK_ISO(%2) AS INTEGER) AS VARCHAR(3)), CAST(CAST(WEEK(%2,0) AS INTEGER) AS VARCHAR(3)))</formula>
 		<formula part='hour'>TO_CHAR(CAST(%2 AS TIMESTAMP(2)), &apos;FMHH24&apos;)</formula>
 		<formula part='minute'>TO_CHAR(CAST(%2 AS TIMESTAMP(2)), &apos;FMMI&apos;)</formula>
 		<formula part='second'>TO_CHAR(CAST(%2 AS TIMESTAMP(2)), &apos;FMSS&apos;)</formula>
@@ -758,8 +760,10 @@
 		<formula part='dayofyear'>DOY(%2)</formula>
 		<formula part='day'>DAY(%2)</formula>
 		<formula part='weekday'>DAYOFWEEK(%2)</formula>
-		<formula part='week'>WEEK(%2,0)</formula>
-	    <formula part='hour'>HOUR(%2)</formula>
+		<!-- The conditional check %3=1 in the next formula part checks if the test case 3rd parameter is 'monday' ('sunday'=0, 'monday'=1)-->
+		<!-- Possible TODO: Handle other DOW values for the 3rd parameter (e.g. 'wednesday', 'thursday', etc.)-->
+		<formula part='week'>IF(%3=1, WEEK_ISO(%2), WEEK(%2,0))</formula>
+		<formula part='hour'>HOUR(%2)</formula>
 		<formula part='minute'>MINUTE(%2)</formula>
 		<formula part='second'>SECOND(%2)</formula>
 		<argument type='localstr' />


### PR DESCRIPTION
### Summary
Remedy for failures that occur in TDVT test cases **datename.sow.week** and **datepart.sow.week** with **sow='monday'** using the Actian JDBC Connector. A couple other minor formatting issues were also fixed.

### Affected TDVT Test Cases
JIra Issue | Test Name | Test Case
--|--|--
[II-12238](https://actian.atlassian.net/browse/II-12238) | date.datename.sow.week | DATENAME('week', [date2], 'monday')<br>DATENAME('week', [datetime0], 'monday')
[II-12239](https://actian.atlassian.net/browse/II-12239) | date.datepart.sow.week | DATEPART('week', [date2], 'monday')<br>DATEPART('week', [datetime0], 'monday')

**Important Note:** The test cases involving field `date2` are not yet passing due to Connector SDK issue [#1182](https://github.com/tableau/connector-plugin-sdk/issues/1182). If the Tableau Connector SDK team agrees to update the expected files, this should allow the two `date2` tests to pass.

### TDVT Results
Note | Passed | Failed | Total
--|--|--|--
Before Fix | 837 | 31 | 868
After Fix | 839 | 29 | 868

### Test Results
[test_results_combined-BEFOREFIXES.csv](https://github.com/ActianCorp/actian_tableau_connector/files/12676993/test_results_combined-BEFOREFIXES.csv)
[test_results_combined-AFTERFIXES.csv](https://github.com/ActianCorp/actian_tableau_connector/files/12676992/test_results_combined-AFTERFIXES.csv)