### PR TITLE
TDVT DATETRUNC WEEK fix with SOW = monday for II-12240

### DIFF
--- a/actian_jdbc/dialect.tdd
+++ b/actian_jdbc/dialect.tdd
@@ -804,7 +804,9 @@
 		<formula part='hour'>TO_TIMESTAMP(TO_CHAR(%2, &apos;YYYY-MM-DD HH24&apos;), &apos;YYYY-MM-DD HH24&apos;)</formula>
 		<formula part='minute'>TO_TIMESTAMP(TO_CHAR(%2, &apos;YYYY-MM-DD HH24:MI&apos;), &apos;YYYY-MM-DD HH24:MI&apos;)</formula>
 		<formula part='second'>TO_TIMESTAMP(TO_CHAR(%2, &apos;YYYY-MM-DD HH24:MI:SS&apos;), &apos;YYYY-MM-DD HH24:MI:SS&apos;)</formula>
-		<formula part='week'>TRUNC((DATE_TRUNC('YEAR', %2) + interval '1' day * 7 * week(%2,0)),'IW') - 1</formula>
+		<!-- The conditional check %3=1 in the next formula part checks if the test case 3rd parameter is 'monday' ('sunday'=0, 'monday'=1)-->
+		<!-- Possible TODO: Handle other DOW values for the 3rd parameter (e.g. 'wednesday', 'thursday', etc.)-->
+		<formula part='week'>IF(%3=1, DATE_TRUNC('WEEK', %2), TRUNC((DATE_TRUNC('YEAR', %2) + interval '1' day * 7 * week(%2,0)),'IW') - 1)</formula>
 		<argument type='localstr' />
 		<argument type='date' />
 		<argument type='localstr' />


### PR DESCRIPTION
### Summary
Remedy for failures that occur in TDVT test case **datetrunc.sow.week** with **sow='monday'** using the Actian JDBC Connector.

**Related Jira Issue:** [II-12240](https://actian.atlassian.net/browse/II-12240)

### TDVT DATETRUNC Test Cases
Test Case | Without Fix | With Fix
--|--|--
DATETRUNC('week', [date2], 'monday') | _**Fail**_ | Pass
DATETRUNC('week', [date2], 'sunday') | Pass | Pass
DATETRUNC('week', [datetime0], 'monday') | _**Fail**_ | Pass
DATETRUNC('week', [datetime0], 'sunday') | Pass | Pass
DATETRUNC('week', [date2]) | Pass | Pass
DATETRUNC('week', [datetime0]) | Pass | Pass
DATETRUNC('week', DATE(null)) | Pass | Pass
DATETRUNC('week', DATETIME(null)) | Pass | Pass
DATETRUNC('week', DATETIME(null), 'sunday') | Pass | Pass
DATETRUNC('week', DATE(null), 'sunday') | Pass | Pass

### TDVT Results
Note | Passed | Failed | Total
--|--|--|--
Without Fix | 839 | 29 | 868
With Fix | 841 | 27 | 868

### Test Results
[test_results_combined-BeforeTruncFix.csv](https://github.com/ActianCorp/actian_tableau_connector/files/12688805/test_results_combined-BeforeTruncFix.csv)
[test_results_combined-AfterTruncFix.csv](https://github.com/ActianCorp/actian_tableau_connector/files/12688804/test_results_combined-AfterTruncFix.csv)