### PR TITLE
Fix string.contains tests II-12244, II-12245, II-12500

### DIFF
--- a/actian_jdbc/dialect.tdd
+++ b/actian_jdbc/dialect.tdd
@@ -456,7 +456,7 @@
 		<argument type='str' />
     </function>
     <function group='string' name='CONTAINS' return-type='bool'>
-		<formula>(CASE WHEN %2 IS NULL OR %1 IS NULL THEN NULL WHEN  CHARACTER_LENGTH(%2) &gt;= 1 AND %1 CONTAINING (%2) THEN TRUE ELSE FALSE END)  IS TRUE</formula>
+		<formula>(LOCATE(%1,%2) != SIZE(%1)+1) AND (LOCATE(%1,%2) > 0)</formula>
 		<argument type='str' />
 		<argument type='str' />
     </function>

--- a/actian_odbc/dialect.tdd
+++ b/actian_odbc/dialect.tdd
@@ -442,7 +442,7 @@
 		<argument type='str' />
     </function>
     <function group='string' name='CONTAINS' return-type='bool'>
-		<formula>(CASE WHEN %2 IS NULL OR %1 IS NULL THEN NULL WHEN  CHARACTER_LENGTH(%2) &gt;= 1 AND %1 CONTAINING (%2) THEN TRUE ELSE FALSE END)  IS TRUE</formula>
+	        <formula>(LOCATE(%1,%2) != SIZE(%1)+1) AND (LOCATE(%1,%2) > 0)</formula>
 		<argument type='str' />
 		<argument type='str' />
     </function>


### PR DESCRIPTION
### Summary
Change of formula in Actian dialect **CONTAINS** function fixes failures for several **string.contains** test cases.

Jira Ticket | Test Cases | Before Fix | After Fix
--|--|--|--
[II-12244](https://actian.atlassian.net/browse/II-12244) | CONTAINS([str1], Null)<br>CONTAINS([str2], Null) | FAIL | PASS
[II-12245](https://actian.atlassian.net/browse/II-12245) | CONTAINS(str2, "A(")<br>CONTAINS(str2, "A\(") | FAIL | PASS
[II-12500](https://actian.atlassian.net/browse/II-12500) | CONTAINS(str2, "e")<br>CONTAINS(str1, "IND") | FAIL | PASS

### Full TDVT Suite Test Results
Tests | Before Fix | After Fix
--|--|--
Pass | 850 | 854
Fail | 20 | 14
Total | 868 | 868

[test_results_combined-BASELINE000.csv](https://github.com/ActianCorp/actian_tableau_connector/files/12859580/test_results_combined-BASELINE000.csv)
[test_results_combined-BEFOREFIX.csv](https://github.com/ActianCorp/actian_tableau_connector/files/12835560/test_results_combined-BEFOREFIX.csv)
[test_results_combined-AFTERFIX.csv](https://github.com/ActianCorp/actian_tableau_connector/files/12835559/test_results_combined-AFTERFIX.csv)

### Update
I mistakenly left issue [II-12500](https://actian.atlassian.net/browse/II-12500) off the initial post of this PR even though the issue was in fact also fixed by this PR.

There are now 3 CSV results files attached above.
- **test_results_combined-BASELINE000.csv** - Initial baseline TDVT run in which all 6 listed test cases failed.
- **test_results_combined-BEFOREFIX.csv** - Later TDVT run in which 2 of 6 test cases passed and 4 of 6 failed.
- **test_results_combined-AFTERFIX.csv** - Final TDVT run in which all 6 passed.