### PR TITLE
Bump version to 1.0.5

### DIFF
--- a/actian_jdbc/manifest.xml
+++ b/actian_jdbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='actian_jdbc' superclass='jdbc' plugin-version='1.0.4' name='Actian Avalanche JDBC' version='18.1'>
+<connector-plugin class='actian_jdbc' superclass='jdbc' plugin-version='1.0.5' name='Actian Avalanche JDBC' version='18.1'>
   <!--
       Including company_name results in "By Actian" being added to the end of the connector name.
       Not including company_name but including <vendor-information> with url,

--- a/actian_odbc/manifest.xml
+++ b/actian_odbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='actian_odbc' superclass='odbc' plugin-version='1.0.4' name='Actian Avalanche ODBC' version='18.1'>
+<connector-plugin class='actian_odbc' superclass='odbc' plugin-version='1.0.5' name='Actian Avalanche ODBC' version='18.1'>
   <!--
       Including company_name results in "By Actian" being added to the end of the connector name.
       Not including company_name but including <vendor-information> with url,


### PR DESCRIPTION
The latest version [1.0.4](https://github.com/ActianCorp/actian_tableau_connector/releases/tag/1.0.4) was just released. Now, bumping the version in manifest.xml will prepare for the next release.