### PR TITLE
Change Avalanche references to Actian Data Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Actian Tableau Connector
 
-Tableau connector (aka taco) for Actian Avalanche, Vector, and Ingres.
+Tableau connector (aka taco) for Actian Data Platform, Vector, and Ingres.
 
 Install from https://extensiongallery.tableau.com/connectors
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -86,7 +86,7 @@ If running test suite, see [data loading readme](https://github.com/clach04/conn
 
 For running the test suite, Tableau expects the non-default mixed case. This will not be needed for https://github.com/tableau/connector-plugin-sdk/issues/216 (`CAP_ODBC_BIND_DETECT_ALIAS_CASE_FOLDING`)
 
-If your object name case is all lower case (which is the default for Actian Avalanche/Vector/ActianX/Ingres) mixed case option is **not** required.
+If your object name case is all lower case (which is the default for Actian Data Platform / Vector / ActianX / Ingres) mixed case option is **not** required.
 
 I.e. mixed case is required if running Tableau Connector SDK tests suite.
 

--- a/actian_jdbc/README.md
+++ b/actian_jdbc/README.md
@@ -21,7 +21,7 @@ Install JDBC jar file, Tableau instructions for this are located at [Tableau Dri
 
 Obtain iijdbc.jar and copy into `C:\Program Files\Tableau\Drivers`
 
-iijdbc.jar can either be downloaded from [ESD](https://esd.actian.com/product/Avalanche/JDBC/java/Actian_Avalanche_JDBC_Drivers)
+iijdbc.jar can either be downloaded from [ESD](https://esd.actian.com/product/Actian_Data_Platform/JDBC/java/Actian_Data_Platform_JDBC_Drivers)
 or obtained from a client installation from:
 
   * `%II_SYSTEM%\ingres\lib\iijdbc.jar` - Windows

--- a/actian_jdbc/manifest.xml
+++ b/actian_jdbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='actian_jdbc' superclass='jdbc' plugin-version='1.0.5' name='Actian Avalanche JDBC' version='18.1'>
+<connector-plugin class='actian_jdbc' superclass='jdbc' plugin-version='1.0.5' name='Actian Data Platform JDBC' version='18.1'>
   <!--
       Including company_name results in "By Actian" being added to the end of the connector name.
       Not including company_name but including <vendor-information> with url,

--- a/actian_odbc/README.md
+++ b/actian_odbc/README.md
@@ -18,7 +18,7 @@ Usage
 
 ### Install ODBC driver
 
-Install ODBC Driver from [ESD](https://esd.actian.com/product/Avalanche/Client_Runtime)
+Install ODBC Driver from [ESD](https://esd.actian.com/product/Actian_Data_Platform/Client_Runtime)
 
 NOTE Tableau Desktop is a 64-bit product, it requires a 64-Bit ODBC Driver client installation.
 

--- a/actian_odbc/manifest.xml
+++ b/actian_odbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='actian_odbc' superclass='odbc' plugin-version='1.0.5' name='Actian Avalanche ODBC' version='18.1'>
+<connector-plugin class='actian_odbc' superclass='odbc' plugin-version='1.0.5' name='Actian Data Platform ODBC' version='18.1'>
   <!--
       Including company_name results in "By Actian" being added to the end of the connector name.
       Not including company_name but including <vendor-information> with url,

--- a/tests/datasets/TestV1/actian/README.md
+++ b/tests/datasets/TestV1/actian/README.md
@@ -1,4 +1,4 @@
-# Hosting TestV1 in Actian Cloud Avalanche local Vector/ActianX/Ingres
+# Hosting TestV1 in Actian Data Platform and local Vector/ActianX/Ingres
 
 Test data is provided in utf8 encoding, the DBMS character set should match this setting.
 An alternative WIN1252 encoded data set is available, to use this edit `load_staples.sql` and see the commented out code section.


### PR DESCRIPTION
**`Actian Avalanche`** has been renamed to **`Actian Data Platform`**.

This PR updates the name in the various readme files and manifest.xml files for the Actian Tableau Connector.

There is one [README](https://github.com/ActianCorp/actian_tableau_connector/blob/master/actian_odbc/README.md) for which the following link still has "avalanche" in the URL path. This link will also need to be changed once the documentation team updates the path.

`https://docs.actian.com/avalanche/index.html#page/Connectivity/Connection_String_Keywords.htm`
