### PR TITLE
Script to work with Jenkins in packaging and signing tacos

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,57 @@
+## Setup notes for machine that executes the script
+Create user: atc
+Create directory: $HOME/tableau/scripts
+Place script package_sign_tacos.sh into the $HOME/tableau/scripts directory
+Create the Jenkins workspace root directory (e.g. /var/lib/jenkins) and give read/write/execute permission to user **atc**.
+Configure the node in Jenkins.
+Command line packages required by the script: jdk, git, unzip, smctl
+
+The script has been tested on Ubuntu release 20.04 and OpenJDK 1.8.0_392.
+
+## Example Jenkins Project Configuration
+
+### Section: General
+
+Parameter
+  Type: Label
+  Name: NODE
+  Default Value: (host name)
+
+Parameter
+  Type: String Parameter
+  Name: SCRIPT_PATH
+  Default Value: $HOME/tableau/scripts
+
+Parameter
+  Type: String Parameter
+  Name: BRANCH
+  Default Value: (none)
+
+Check box: Restrict where this project can be run (checked)
+  Label Expression: (host name)
+
+### Section: Build Environment
+
+Check box: Set Build Name (checked)
+  Build Name: ${BUILD_NUMBER}_ACTIAN_TABLEAU_CONNECTOR
+
+### Section: Build
+
+Execute shell
+  Command:
+     bash
+     cd $SCRIPT_PATH
+     $SCRIPT_PATH/package_sign_tacos.sh ${BUILD_NUMBER} ${WORKSPACE} ${BRANCH}
+     if [ $? -eq 0 ]
+     then	
+       echo "Packaging and signing operations completed. Check outcome."
+     else
+       exit 3
+     fi
+
+### Section: Post-build Actions
+
+Archive the artifacts
+  Files to archive: actian*.taco.build_${BUILD_NUMBER}
+
+Attach Build Log: Attach Build Log

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,7 +1,7 @@
 ## Setup notes for machine that executes the script (Linux example)
-Create new user.
+Create a new user.  
 Create directory: `$HOME/tableau/scripts`  
-Place script package_sign_tacos.sh into the `$HOME/tableau/scripts` directory  
+Place script package_sign_tacos.sh into the `$HOME/tableau/scripts` directory.  
 Create the Jenkins workspace root directory (e.g. `/var/lib/jenkins`) and give read/write/execute permission to the user.  
 Configure the node in Jenkins.  
 Command line packages required by the script: jdk, git, unzip, smctl  

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,57 +1,60 @@
-## Setup notes for machine that executes the script
-Create user: atc
-Create directory: $HOME/tableau/scripts
-Place script package_sign_tacos.sh into the $HOME/tableau/scripts directory
-Create the Jenkins workspace root directory (e.g. /var/lib/jenkins) and give read/write/execute permission to user **atc**.
-Configure the node in Jenkins.
-Command line packages required by the script: jdk, git, unzip, smctl
+## Setup notes for machine that executes the script  
+Create user: atc  
+Create directory: `$HOME/tableau/scripts`  
+Place script package_sign_tacos.sh into the `$HOME/tableau/scripts` directory  
+Create the Jenkins workspace root directory (e.g. `/var/lib/jenkins`) and give read/write/execute permission to user `atc`.  
+Configure the node in Jenkins.  
+Command line packages required by the script: jdk, git, unzip, smctl  
 
 The script has been tested on Ubuntu release 20.04 and OpenJDK 1.8.0_392.
 
-## Example Jenkins Project Configuration
+## Example Jenkins project configuration
 
 ### Section: General
 
-Parameter
-  Type: Label
-  Name: NODE
-  Default Value: (host name)
+**Parameter**  
+ - Type: Label
+ - Name: `NODE`
+ - Default Value: (host name where script exists)
 
-Parameter
-  Type: String Parameter
-  Name: SCRIPT_PATH
-  Default Value: $HOME/tableau/scripts
+**Parameter**  
+ - Type: String Parameter
+ - Name: `SCRIPT_PATH`
+ - Default Value: `$HOME/tableau/scripts`
 
-Parameter
-  Type: String Parameter
-  Name: BRANCH
-  Default Value: (none)
+**Parameter**  
+ - Type: String Parameter
+ - Name: `BRANCH`
+ - Default Value: (blank)
 
-Check box: Restrict where this project can be run (checked)
-  Label Expression: (host name)
+**Check box:** Restrict where this project can be run (checked)
+ - Label Expression: host name
 
 ### Section: Build Environment
 
 Check box: Set Build Name (checked)
-  Build Name: ${BUILD_NUMBER}_ACTIAN_TABLEAU_CONNECTOR
+ - Build Name: `${BUILD_NUMBER}_ACTIAN_TABLEAU_CONNECTOR`
 
 ### Section: Build
 
-Execute shell
-  Command:
-     bash
-     cd $SCRIPT_PATH
-     $SCRIPT_PATH/package_sign_tacos.sh ${BUILD_NUMBER} ${WORKSPACE} ${BRANCH}
-     if [ $? -eq 0 ]
-     then	
-       echo "Packaging and signing operations completed. Check outcome."
-     else
-       exit 3
-     fi
+**Execute shell** - Command  
+
+     bash  
+     cd $SCRIPT_PATH  
+     $SCRIPT_PATH/package_sign_tacos.sh ${BUILD_NUMBER} ${WORKSPACE} ${BRANCH}  
+     if [ $? -eq 0 ]  
+     then  
+       echo "Packaging and signing operations completed. Check outcome."  
+     else  
+       exit 3  
+     fi  
 
 ### Section: Post-build Actions
 
-Archive the artifacts
-  Files to archive: actian*.taco.build_${BUILD_NUMBER}
+#### Archive the artifacts  
 
-Attach Build Log: Attach Build Log
+**Files to archive**  `actian*.taco.build_${BUILD_NUMBER}`
+
+#### Attach Build Log
+
+     Attach Build Log

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,12 +1,19 @@
-## Setup notes for machine that executes the script  
-Create user: atc  
+## Setup notes for machine that executes the script (Linux example)
+Create new user.
 Create directory: `$HOME/tableau/scripts`  
 Place script package_sign_tacos.sh into the `$HOME/tableau/scripts` directory  
-Create the Jenkins workspace root directory (e.g. `/var/lib/jenkins`) and give read/write/execute permission to user `atc`.  
+Create the Jenkins workspace root directory (e.g. `/var/lib/jenkins`) and give read/write/execute permission to the user.  
 Configure the node in Jenkins.  
 Command line packages required by the script: jdk, git, unzip, smctl  
 
-The script has been tested on Ubuntu release 20.04 and OpenJDK 1.8.0_392.
+## Jenkins Node Configuration
+
+**Remote root directory** - Match location on machine. e.g. `/var/lib/jenkins`  
+**Usage** - `Use this node as much as possible`  
+**Launch method** - `Launch agents via SSH`  
+**Host** - Machine name  
+**Credentials** - Will need to create Jenkins credentials matching the user where the script is located.  
+**Host Key Verification Strategy** - `Non verifying Verification Strategy`  
 
 ## Example Jenkins project configuration
 
@@ -16,6 +23,7 @@ The script has been tested on Ubuntu release 20.04 and OpenJDK 1.8.0_392.
  - Type: Label
  - Name: `NODE`
  - Default Value: (host name where script exists)
+ - Important
 
 **Parameter**  
  - Type: String Parameter
@@ -58,3 +66,5 @@ Check box: Set Build Name (checked)
 #### Attach Build Log
 
      Attach Build Log
+
+The script `package_sign_tacos.sh` has been tested on Ubuntu release 20.04 with OpenJDK 1.8.0_392.

--- a/scripts/package_sign_tacos.sh
+++ b/scripts/package_sign_tacos.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# Script for packaging and signing Actian Tableau connectors
+#
+# Parameters passed to script:
+#   1) Build number (required)
+#   2) Jenkins Workspace (required)
+#   3) Branch name (optional)
+#
+# Requirements prior to running script:
+#   - Digicert Software Trust Manager is installed and configured.
+#   - The command "smctl healthcheck" runs successfully, reporting:
+#     - A valid signer certificate is available.
+#     - The user has the privilege to sign.
+#
+
+# Verify that build number was passed in
+if [ -z $1 ]; then
+   echo Missing build number parameter
+   exit 1
+fi
+
+BUILD=$1
+
+# Verify that Jenkins workspace directorywas passed in
+if [ -z $2 ]; then
+   echo Missing workspace directory parameter
+   exit 1
+fi
+
+WKSP=$JENKINS_HOME/$2
+echo Using Jenkins workspace: $WKSP
+
+# Check if branch name was passed
+if [ $3 ]; then
+   BRANCH="-b $3"
+fi
+echo DEBUG BRANCH=$BRANCH
+
+# Check prerequisites
+if [ -z $(which jarsigner) ]; then
+   echo jarsigner not found
+   exit 1
+fi
+
+# Set directory variables
+BASEDIR=$HOME/tableau
+TACODIR=$BASEDIR/tacos
+LOGDIR=$BASEDIR/logs
+SCRIPTDIR=$BASEDIR/scripts
+GITHUBDIR=$BASEDIR/github
+ACTIANDIR=$GITHUBDIR/actian_tableau_connector
+JDBCDIR=$ACTIANDIR/actian_jdbc
+ODBCDIR=$ACTIANDIR/actian_odbc
+TABSDKDIR=$GITHUBDIR/connector-plugin-sdk
+PKGRDIR=$GITHUBDIR/connector-plugin-sdk/connector-packager
+
+# Ensure subdirectories exist
+if [ ! -d "$TACODIR" ]; then
+  mkdir -p $TACODIR/unsigned
+fi
+if [ ! -d "$LOGDIR" ]; then
+  mkdir $LOGDIR
+fi
+
+# Set repo variables
+TABSDKREPO=https://github.com/tableau/connector-plugin-sdk.git
+ACTIANREPO=https://github.com/ActianCorp/actian_tableau_connector.git
+
+TS=$(date +"%Y%b%d-%H%M%S")
+
+# Log parameters passed to script
+echo $TS  $BUILD  $WKSP >> $LOGDIR/builds.log
+
+cd $BASEDIR
+
+# Create Python vitual environment
+python -m venv .venv
+. ./.venv/bin/activate
+
+# Clone repositories#
+rm -rf $GITHUBDIR/*
+git clone $BRANCH $ACTIANREPO $ACTIANDIR
+git clone $TABSDKREPO $TABSDKDIR
+
+# Get version from manifest.xml
+VERJDBC=$(grep plugin-version $JDBCDIR/manifest.xml  | cut -d '=' -f4 | cut -d "'" -f2)
+VERODBC=$(grep plugin-version $ODBCDIR/manifest.xml  | cut -d '=' -f4 | cut -d "'" -f2)
+
+# Set taco file names
+JDBC_TACO=actian_jdbc-v$VERJDBC.taco
+ODBC_TACO=actian_odbc-v$VERODBC.taco
+JDBC_TACO_FINAL=$JDBC_TACO.build_$BUILD
+ODBC_TACO_FINAL=$ODBC_TACO.build_$BUILD
+
+# Package tacos
+cd $TABSDKDIR/connector-packager
+python setup.py install
+python -m connector_packager.package $JDBCDIR  --dest $TACODIR -l $LOGDIR
+mv $LOGDIR/packaging_logs.txt $LOGDIR/packaging_logs_jdbc_build_$BUILD.txt
+python -m connector_packager.package $ODBCDIR  --dest $TACODIR -l $LOGDIR
+mv $LOGDIR/packaging_logs.txt $LOGDIR/packaging_logs_odbc_build_$BUILD.txt
+
+cd $BASEDIR
+
+# Set environment variables needed for accessing certificate
+export SM_HOST=https://clientauth.one.digicert.com
+export SM_CLIENT_CERT_FILE=/usr/local/digicert/certs/Certificate_pkcs12.p12
+
+#Sign tacos
+jarsigner -keystore NONE -storepass NONE -storetype PKCS11 -sigalg SHA256withRSA -providerClass sun.security.pkcs11.SunPKCS11 -providerArg /usr/local/digicert/bin/pkcs11properties.cfg -signedjar $TACODIR/$JDBC_TACO_FINAL -sigfile Actian -tsa http://timestamp.digicert.com $TACODIR/$JDBC_TACO vector_oct_2023_2026
+jarsigner -keystore NONE -storepass NONE -storetype PKCS11 -sigalg SHA256withRSA -providerClass sun.security.pkcs11.SunPKCS11 -providerArg /usr/local/digicert/bin/pkcs11properties.cfg -signedjar $TACODIR/$ODBC_TACO_FINAL -sigfile Actian -tsa http://timestamp.digicert.com $TACODIR/$ODBC_TACO vector_oct_2023_2026
+
+# Keep unsigned taco files and logs
+mv $TACODIR/$JDBC_TACO $TACODIR/unsigned/$JDBC_TACO.UNSIGNED.$BUILD
+mv $TACODIR/$ODBC_TACO $TACODIR/unsigned/$ODBC_TACO.UNSIGNED.$BUILD
+
+# Report final taco files
+echo
+echo Signed Taco Files on $(hostname):
+echo $TACODIR/$JDBC_TACO_FINAL
+echo $TACODIR/$ODBC_TACO_FINAL
+echo
+
+cp $TACODIR/$JDBC_TACO_FINAL $WKSP/
+cp $TACODIR/$ODBC_TACO_FINAL $WKSP/
+
+# Report certificate timestamps and taco version from manifest.xml
+echo ==========  Taco versions and timestamps  ==========
+echo JDBC Taco: $JDBC_TACO_FINAL
+echo Version $VERJDBC
+jarsigner -verbose -verify $TACODIR/$JDBC_TACO_FINAL | grep expire
+echo ----------------------------------------------------
+echo ODBC Taco: $ODBC_TACO_FINAL
+echo Version $VERODBC
+jarsigner -verbose -verify $TACODIR/$ODBC_TACO_FINAL | grep expire
+echo ====================================================
+echo
+

--- a/scripts/package_sign_tacos.sh
+++ b/scripts/package_sign_tacos.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Script for packaging and signing Actian Tableau connectors
 #
 # Parameters passed to script:
@@ -13,6 +11,26 @@
 #     - A valid signer certificate is available.
 #     - The user has the privilege to sign.
 #
+
+# Set repository variables
+TABSDKREPO=https://github.com/tableau/connector-plugin-sdk.git
+ACTIANREPO=https://github.com/ActianCorp/actian_tableau_connector.git
+
+# Set directory variables
+BASEDIR=$HOME/tableau
+TACODIR=$BASEDIR/tacos
+LOGDIR=$BASEDIR/logs
+SCRIPTDIR=$BASEDIR/scripts
+GITHUBDIR=$BASEDIR/github
+ACTIANDIR=$GITHUBDIR/actian_tableau_connector
+JDBCDIR=$ACTIANDIR/actian_jdbc
+ODBCDIR=$ACTIANDIR/actian_odbc
+TABSDKDIR=$GITHUBDIR/connector-plugin-sdk
+PKGRDIR=$GITHUBDIR/connector-plugin-sdk/connector-packager
+
+# Set environment variables needed for accessing certificate
+export SM_HOST=https://clientauth.one.digicert.com
+export SM_CLIENT_CERT_FILE=/usr/local/digicert/certs/Certificate_pkcs12.p12
 
 # Verify that build number was passed in
 if [ -z $1 ]; then
@@ -37,23 +55,11 @@ if [ $3 ]; then
 fi
 echo DEBUG BRANCH=$BRANCH
 
-# Check prerequisites
+# Check for jarsigner command
 if [ -z $(which jarsigner) ]; then
    echo jarsigner not found
    exit 1
 fi
-
-# Set directory variables
-BASEDIR=$HOME/tableau
-TACODIR=$BASEDIR/tacos
-LOGDIR=$BASEDIR/logs
-SCRIPTDIR=$BASEDIR/scripts
-GITHUBDIR=$BASEDIR/github
-ACTIANDIR=$GITHUBDIR/actian_tableau_connector
-JDBCDIR=$ACTIANDIR/actian_jdbc
-ODBCDIR=$ACTIANDIR/actian_odbc
-TABSDKDIR=$GITHUBDIR/connector-plugin-sdk
-PKGRDIR=$GITHUBDIR/connector-plugin-sdk/connector-packager
 
 # Ensure subdirectories exist
 if [ ! -d "$TACODIR" ]; then
@@ -63,10 +69,6 @@ if [ ! -d "$LOGDIR" ]; then
   mkdir $LOGDIR
 fi
 
-# Set repo variables
-TABSDKREPO=https://github.com/tableau/connector-plugin-sdk.git
-ACTIANREPO=https://github.com/ActianCorp/actian_tableau_connector.git
-
 TS=$(date +"%Y%b%d-%H%M%S")
 
 # Log parameters passed to script
@@ -74,8 +76,8 @@ echo $TS  $BUILD  $WKSP >> $LOGDIR/builds.log
 
 cd $BASEDIR
 
-# Create Python vitual environment
-python -m venv .venv
+# Create Python vitual environment (tested with Python 3.8.10)
+python3 -m venv .venv
 . ./.venv/bin/activate
 
 # Clone repositories#
@@ -102,10 +104,6 @@ python -m connector_packager.package $ODBCDIR  --dest $TACODIR -l $LOGDIR
 mv $LOGDIR/packaging_logs.txt $LOGDIR/packaging_logs_odbc_build_$BUILD.txt
 
 cd $BASEDIR
-
-# Set environment variables needed for accessing certificate
-export SM_HOST=https://clientauth.one.digicert.com
-export SM_CLIENT_CERT_FILE=/usr/local/digicert/certs/Certificate_pkcs12.p12
 
 #Sign tacos
 jarsigner -keystore NONE -storepass NONE -storetype PKCS11 -sigalg SHA256withRSA -providerClass sun.security.pkcs11.SunPKCS11 -providerArg /usr/local/digicert/bin/pkcs11properties.cfg -signedjar $TACODIR/$JDBC_TACO_FINAL -sigfile Actian -tsa http://timestamp.digicert.com $TACODIR/$JDBC_TACO vector_oct_2023_2026


### PR DESCRIPTION
### Description
The script `package_sign_tacos.sh` is used with the instructions in the associated README as part of a Jenkins project that packages and signs Actian Tableau JDBC and ODBC connectors (tacos). The tacos are built from the latest code of the specified branch, using the `master` branch as the default.

### Jenkins Project
[Tableau_Connector](https://alm.actian.com/jenkins/ea/job/Tableau_Connector/)

### Location of Tacos
After the Jenkins build/script finishes, the JDBC and ODBC tacos are attached to the associated Jenkins build and can be downloaded for immediate use with Tableau tools.

### Taco Versions and Timestamps
The versions and timestamps of the JDBC and ODBC tacos can be found in the **Console Output** for the associated build.