### PR TITLE
Bumped version for release 1.0.6

### DIFF
--- a/actian_jdbc/manifest.xml
+++ b/actian_jdbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='actian_jdbc' superclass='jdbc' plugin-version='1.0.5' name='Actian Data Platform JDBC' version='18.1'>
+<connector-plugin class='actian_jdbc' superclass='jdbc' plugin-version='1.0.6' name='Actian Data Platform JDBC' version='18.1'>
   <!--
       Including company_name results in "By Actian" being added to the end of the connector name.
       Not including company_name but including <vendor-information> with url,

--- a/actian_odbc/manifest.xml
+++ b/actian_odbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='actian_odbc' superclass='odbc' plugin-version='1.0.5' name='Actian Data Platform ODBC' version='18.1'>
+<connector-plugin class='actian_odbc' superclass='odbc' plugin-version='1.0.6' name='Actian Data Platform ODBC' version='18.1'>
   <!--
       Including company_name results in "By Actian" being added to the end of the connector name.
       Not including company_name but including <vendor-information> with url,


### PR DESCRIPTION
### Description
Version 1.0.6 will be a new release containing the name change from `Actian Avalanche` to `Actian Data Platform` that was handled via PR [47](https://github.com/ActianCorp/actian_tableau_connector/pull/47).

### TDVT Testing Configuration
Tacos were built from the temp branch via Jenkins Tableau_Connector job [42](https://alm.actian.com/jenkins/ea/job/Tableau_Connector/42/).

The JDBC taco was tested using the TDVT suite with Tableau Desktop 2023.2 on Microsoft Windows [Version 10.0.19042.2965] connecting to Vector 6.3.0 (a64.lnx/146) 14608 on Ubuntu 20.04.

The exclusions recommended by Tableau were in place for the TDVT testing.  See [comment](https://actian.atlassian.net/browse/II-12220?focusedCommentId=870768)

### TDVT Test Results for JDBC taco build 42 with the recommended exclusions enabled

     Test Count: 833 tests
             Passed tests: 825
             Failed tests: 8
             Tests run: 833
             Disabled tests: 0
             Skipped tests: 0

     Other information:
             Smoke test time: 14.49 seconds
             Main test time: 71.82 seconds
             Total time: 86.31 seconds

**Note:** The 8 failed tests are known issues with Jira tickets already open under epic [II-12220](https://actian.atlassian.net/browse/II-12220).