### PR TITLE
Updates allowing XSD validation to pass

### DIFF
--- a/actian_jdbc/connectionBuilder.js
+++ b/actian_jdbc/connectionBuilder.js
@@ -11,7 +11,7 @@
         urlBuilder = "jdbc:ingres://" + attr[connectionHelper.attributeServer] + ":" + attr[connectionHelper.attributePort] + "/" + attr[connectionHelper.attributeDatabase] + ";";
     }
 
-    if (attr["use_select_loops"] == "require")
+    if (attr["v-use-select-loops"] == "require")
     {
         urlBuilder += "SELECT_LOOP=ON;";
     }

--- a/actian_jdbc/connectionFields.xml
+++ b/actian_jdbc/connectionFields.xml
@@ -17,7 +17,7 @@
       <true-value value="require" />
     </boolean-options>
   </field>
-  <field name="use_select_loops" label="Use select loops for queries (default is to use cursors)" value-type="boolean" category="advanced" default-value="">
+  <field name="v-use-select-loops" label="Use select loops for queries (default is to use cursors)" value-type="boolean" category="advanced" default-value="">
     <boolean-options>
       <false-value value="" />
       <true-value value="require" />

--- a/actian_jdbc/connectionResolver.tdr
+++ b/actian_jdbc/connectionResolver.tdr
@@ -14,7 +14,7 @@
           <attr>username</attr>
           <attr>password</attr>
           <attr>authentication</attr>
-          <attr>use_select_loops</attr>
+          <attr>v-use-select-loops</attr>
           <attr>sslmode</attr>
         </attribute-list>
       </required-attributes>

--- a/actian_jdbc/manifest.xml
+++ b/actian_jdbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='actian_jdbc' superclass='jdbc' plugin-version='1.0.9.2' name='Actian Data Platform JDBC' version='18.1'>
+<connector-plugin class='actian_jdbc' superclass='jdbc' plugin-version='1.0.9.3' name='Actian Data Platform JDBC' version='18.1'>
   <!--
       Including company_name results in "By Actian" being added to the end of the connector name.
       Not including company_name but including <vendor-information> with url,

--- a/actian_odbc/connectionBuilder.js
+++ b/actian_odbc/connectionBuilder.js
@@ -27,12 +27,12 @@
         params["DATABASE"] = params["DATABASE"].slice(0, slash_index);  // strip class, leaving only database name
     }
 
-    if (attr["driver"] !== "")
+    if (attr["v-driver"] !== "")
     {
-        params["DRIVER"] = attr["driver"];
+        params["DRIVER"] = attr["v-driver"];
     }
 
-    if (attr["use_cursors"] == "require")
+    if (attr["v-use-cursors"] == "require")
     {
         params["SELECTLOOPS"] = 'N';
     }

--- a/actian_odbc/connectionFields.xml
+++ b/actian_odbc/connectionFields.xml
@@ -11,11 +11,11 @@
   <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
   <field name="username" label="Username" value-type="string" category="authentication" />
   <field name="password" label="Password" value-type="string" category="authentication" secure="true" optional="true" />
-  <field name="use_cursors" label="Use cursors for queries (default is to use select loops)" value-type="boolean" category="advanced" default-value="">
+  <field name="v-use-cursors" label="Use cursors for queries (default is to use select loops)" value-type="boolean" category="advanced" default-value="">
     <boolean-options>
       <false-value value="" />
       <true-value value="require" />
     </boolean-options>
   </field>
-  <field name="driver" label="Driver" value-type="string" category="advanced" optional="true" />
+  <field name="v-driver" label="Driver" value-type="string" category="advanced" optional="true" />
 </connection-fields>

--- a/actian_odbc/connectionResolver.tdr
+++ b/actian_odbc/connectionResolver.tdr
@@ -10,9 +10,10 @@
           <attr>class</attr>
           <attr>server</attr>
           <attr>port</attr>
-          <attr>driver</attr>
-          <attr>use_cursors</attr>
+          <attr>v-driver</attr>
+          <attr>v-use-cursors</attr>
           <attr>dbname</attr>
+          <attr>authentication</attr>
           <attr>username</attr>
           <attr>password</attr>
           <!--attr>vendor1</attr-->

--- a/actian_odbc/manifest.xml
+++ b/actian_odbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='actian_odbc' superclass='odbc' plugin-version='1.0.9.2' name='Actian Data Platform ODBC' version='18.1'>
+<connector-plugin class='actian_odbc' superclass='odbc' plugin-version='1.0.9.3' name='Actian Data Platform ODBC' version='18.1'>
   <!--
       Including company_name results in "By Actian" being added to the end of the connector name.
       Not including company_name but including <vendor-information> with url,


### PR DESCRIPTION
These updates were needed so that the [XSD validator](https://github.com/tableau/connector-plugin-sdk/blob/master/connector-packager/connector_packager/xsd_validator.py) of the Tableau Connector SDK would pass when trying to package the Actian connectors.

Most of the changes were to fix names of [vendor defined attributes](https://tableau.github.io/connector-plugin-sdk/docs/mcd#vendor-defined) in accordance with Tableau SDK documented requirements.

With the changes, the packaging operation passed for both the JDBC and ODBC connectors. I then successfully sanity tested the packaged connectors with Tableau Desktop version 2024.1.5 being able to load the connectors and connect to a target Vector 6.3 database with the option to query using cursors and alternatively using select loops (see #57).

The next steps will be to update the version of the connectors (likely to 1.0.10) and publish these on the [Releases](https://github.com/ActianCorp/actian_tableau_connector/releases) page, along with QA-certifying the connectors as part of the process in preparing to publish the updated connectors to [Tableau Exchange](https://exchange.tableau.com/)

